### PR TITLE
Add masked background overlay to context chart, according to the design

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,6 @@
   "files.insertFinalNewline": true,
   "files.trimFinalNewlines": true,
   "files.trimTrailingWhitespace": true,
-  "editor.formatOnSave": true,
   "editor.trimAutoWhitespace": true,
   "tslint.autoFixOnSave": true
 }

--- a/packages/standalone-uis/execution-timeline/src/app/execution-timeline/execution-timeline.component.css
+++ b/packages/standalone-uis/execution-timeline/src/app/execution-timeline/execution-timeline.component.css
@@ -12,16 +12,20 @@
 
 :host ::ng-deep .brush > .selection {
   fill: none;
-  stroke:#E1E9EE;
-  box-shadow: 0 2px 4px 0 #E5E9F2;
+  stroke: #e1e9ee;
+  box-shadow: 0 2px 4px 0 #e5e9f2;
   stroke-width: 5;
 }
 
 :host ::ng-deep .domain {
-  stroke: #D8D8D8;
+  stroke: #d8d8d8;
 }
 
+:host ::ng-deep .brush .overlay {
+  fill: rgba(255, 255, 255, 0.5);
+}
 
-:host #focus-chart, :host #focus-chart g {
+:host #focus-chart,
+:host #focus-chart g {
   width: 100%;
 }

--- a/packages/standalone-uis/execution-timeline/src/app/execution-timeline/execution-timeline.component.html
+++ b/packages/standalone-uis/execution-timeline/src/app/execution-timeline/execution-timeline.component.html
@@ -1,10 +1,14 @@
 <Card>
   <div fxFlex fxLayout="column">
-    <div fxFlex>
-      <h3 class="section-heading">Timeline Overview</h3>
-    </div>
+    <div fxFlex><h3 class="section-heading">Timeline Overview</h3></div>
     <div #contextOuterContainer fxFlex>
       <svg #contextContainer width="100%" height="160" (window:resize)="onResizeSVG($event)">
+        <defs>
+          <mask id="selectionMask" x="0" y="0">
+            <rect id="selectionMaskCutout" fill="white" />
+            <rect id="selectionMaskBackground" x="100" y="0" width="100" height="100%" fill="black" />
+          </mask>
+        </defs>
         <g #contextContent></g>
         <g #contextAxis></g>
         <g #contextBrush class="brush"></g>
@@ -15,9 +19,7 @@
 
 <Card style="margin-top:1em;">
   <div fxFlex fxLayout="column">
-    <div fxFlex>
-      <h3 class="section-heading">Timeline Detail View</h3>
-    </div>
+    <div fxFlex><h3 class="section-heading">Timeline Detail View</h3></div>
     <Legend fxFlex></Legend>
     <div #focusOuterContainer fxFlex="1 1 150px">
       <svg #focusContainer width="100%" (window:resize)="onResizeSVG($event)">

--- a/packages/standalone-uis/execution-timeline/src/app/execution-timeline/execution-timeline.component.ts
+++ b/packages/standalone-uis/execution-timeline/src/app/execution-timeline/execution-timeline.component.ts
@@ -301,6 +301,14 @@ export class ExecutionTimelineComponent implements OnChanges {
     d3.select(this.focusContainerSVGElement.nativeElement)
       .call(zoom)
 
+    d3.select(this.focusOuterContainerElement.nativeElement)
+      .on('wheel.zoom', () => {
+        if (d3.event.shiftKey) {
+          d3.select(this.contextBrushGElement.nativeElement)
+            .call(brush.move, [scaleXContext(scaleXFocus.domain()[0] + d3.event.deltaX), scaleXContext(scaleXFocus.domain()[1] + d3.event.deltaX)])
+        }
+      })
+
     if (lastSegment) {
       const hasPassedMin = lastSegment.end > focusStartSize + 100
       const endMs = hasPassedMin ? focusStartSize : lastSegment.end * .8

--- a/packages/standalone-uis/execution-timeline/src/app/execution-timeline/execution-timeline.component.ts
+++ b/packages/standalone-uis/execution-timeline/src/app/execution-timeline/execution-timeline.component.ts
@@ -266,7 +266,7 @@ export class ExecutionTimelineComponent implements OnChanges {
       .data(this.augurySegments)
       .enter()
       .append('rect')
-      .classed('drag-segment', true)
+      .classed('augury-segment', true)
       .style('fill', 'grey')
       .style('opacity', '0.2')
       .style('pointer-events', 'none')

--- a/packages/standalone-uis/execution-timeline/src/app/execution-timeline/execution-timeline.component.ts
+++ b/packages/standalone-uis/execution-timeline/src/app/execution-timeline/execution-timeline.component.ts
@@ -181,8 +181,13 @@ export class ExecutionTimelineComponent implements OnChanges {
     const brush = d3.brushX()
       .extent([[0, spacingBrush.marginTopAndBottom], [widthContext, Math.max(0, heightContextOuter - spacingBrush.marginTopAndBottom)]])
       .on('brush end', () => {
-        if (d3.event.sourceEvent && d3.event.sourceEvent.type === 'zoom') { return } // ignore brush-by-zoom
         const selection = d3.event.selection || scaleXContext.range()
+        d3.select(this.contextContainerSVGElement.nativeElement)
+          .select('#selectionMaskBackground')
+          .attr('width', selection[1] - selection[0])
+          .attr('x', selection[0])
+
+        if (d3.event.sourceEvent && d3.event.sourceEvent.type === 'zoom') { return } // ignore brush-by-zoom
         if (d3.event.sourceEvent && d3.event.sourceEvent.type === 'end') {
           this.lastPosition = [scaleXContext(selection[0]), scaleXContext(selection[1])]
         }
@@ -307,6 +312,16 @@ export class ExecutionTimelineComponent implements OnChanges {
       d3.select(this.contextBrushGElement.nativeElement)
         .call(brush.move, pos)
   }
+
+  d3.select(this.contextContainerSVGElement.nativeElement)
+    .select('.brush .overlay')
+    .attr('mask', 'url(#selectionMask)')
+
+  d3.select(this.contextContainerSVGElement.nativeElement)
+    .select('#selectionMaskCutout')
+    .style('width', widthContext)
+    .style('height', heightContextInner)
+    .attr('y', spacingContext.marginTop)
 
   d3.select(this.contextBrushGElement.nativeElement)
     .on('mouseover', (d) => {


### PR DESCRIPTION
<img width="849" alt="screen shot 2018-12-10 at 14 55 25" src="https://user-images.githubusercontent.com/898763/49736921-b3ae5300-fc8b-11e8-94c9-193537d7f36a.png">

@andrewthauer I'm not sure about the choice of white overlay here rather than a darker one. It might look better when I can put the more ornate handles and frame on this selection window.