### PR TITLE
refactor(frontend): persisting position and size of popup

### DIFF
--- a/packages/core/src/plugins/popup-controller.class.ts
+++ b/packages/core/src/plugins/popup-controller.class.ts
@@ -7,16 +7,11 @@ interface WindowSizeAndPosition {
 
 export class PopupController {
   public readonly window: AuguryWindow;
-  protected storageKey: string;
+  private storageKey = 'augury-popup-settings';
   private readonly onUnload: () => void;
 
   constructor(protected readonly name: string) {
     this.onUnload = this.kill.bind(this);
-    this.storageKey = `${this.name
-      .toLowerCase()
-      .split(' ')
-      .join('-')}-size-position`;
-
     this.window = this.initializeWindow();
   }
 
@@ -41,8 +36,10 @@ export class PopupController {
     }
 
     const sizeAndPosition = this.getWindowSizeAndPositionFromStorage();
-    pluginWindow.moveTo(sizeAndPosition.position.x, sizeAndPosition.position.y);
-    pluginWindow.resizeTo(sizeAndPosition.size.width, sizeAndPosition.size.height);
+    if (sizeAndPosition) {
+      pluginWindow.moveTo(sizeAndPosition.position.x, sizeAndPosition.position.y);
+      pluginWindow.resizeTo(sizeAndPosition.size.width, sizeAndPosition.size.height);
+    }
 
     window.addEventListener('unload', this.onUnload);
 
@@ -50,13 +47,8 @@ export class PopupController {
   }
 
   private getWindowSizeAndPositionFromStorage(): WindowSizeAndPosition {
-    const defaultSizeAndPosition = {
-      position: { x: 0, y: 0 },
-      size: { width: screen.width, height: screen.height },
-    };
     const fromStorage = localStorage.getItem(this.storageKey);
-
-    return !!fromStorage ? JSON.parse(fromStorage) : defaultSizeAndPosition;
+    return !!fromStorage ? JSON.parse(fromStorage) : null;
   }
 
   private storeWindowSizeAndPosition() {

--- a/packages/core/src/plugins/popup-controller.class.ts
+++ b/packages/core/src/plugins/popup-controller.class.ts
@@ -1,11 +1,22 @@
 import { AuguryWindow } from '../augury-window.interface';
 
+interface WindowSizeAndPosition {
+  position: { x: number; y: number };
+  size: { width: number; height: number };
+}
+
 export class PopupController {
   public readonly window: AuguryWindow;
+  protected storageKey: string;
   private readonly onUnload: () => void;
 
   constructor(protected readonly name: string) {
     this.onUnload = this.kill.bind(this);
+    this.storageKey = `${this.name
+      .toLowerCase()
+      .split(' ')
+      .join('-')}-size-position`;
+
     this.window = this.initializeWindow();
   }
 
@@ -29,16 +40,48 @@ export class PopupController {
       throw new Error('Please allow popup windows');
     }
 
-    pluginWindow.moveTo(0, 0);
-    pluginWindow.resizeTo(screen.width, screen.height);
+    const sizeAndPosition = this.getWindowSizeAndPositionFromStorage();
+    pluginWindow.moveTo(sizeAndPosition.position.x, sizeAndPosition.position.y);
+    pluginWindow.resizeTo(sizeAndPosition.size.width, sizeAndPosition.size.height);
 
     window.addEventListener('unload', this.onUnload);
 
     return pluginWindow;
   }
 
+  private getWindowSizeAndPositionFromStorage(): WindowSizeAndPosition {
+    const defaultSizeAndPosition = {
+      position: { x: 0, y: 0 },
+      size: { width: screen.width, height: screen.height },
+    };
+    const fromStorage = localStorage.getItem(this.storageKey);
+
+    return !!fromStorage ? JSON.parse(fromStorage) : defaultSizeAndPosition;
+  }
+
+  private storeWindowSizeAndPosition() {
+    // Fallback to screen width/height if popup is already closed
+    const outerWidth = this.window.outerWidth === 0 ? screen.width : this.window.outerWidth;
+    const outerHeight = this.window.outerHeight === 0 ? screen.height : this.window.outerHeight;
+
+    const windowSizeAndPosition: WindowSizeAndPosition = {
+      position: {
+        x: this.window.screenX,
+        y: this.window.screenY,
+      },
+      size: {
+        width: outerWidth,
+        height: outerHeight,
+      },
+    };
+
+    localStorage.setItem(this.storageKey, JSON.stringify(windowSizeAndPosition));
+  }
+
   private kill() {
+    this.storeWindowSizeAndPosition();
     this.window.close();
+
     window.removeEventListener('unload', this.onUnload);
   }
 }


### PR DESCRIPTION
Window popup now persist size and position between reloads. Position and size are saved to `localStorage` on page-reload. 

Known limitation: 
- If you close the popup window only, it won't save size/position. User need to close/reload the actual site and not only the performance profiler. This is due to limitations on getting events of when popup is closed separately.