### PR TITLE
fix: remove webpack prod build for perf plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "conventional-changelog": "^3.1.3",
     "conventional-changelog-cli": "^2.0.12",
     "copy-webpack-plugin": "^4.6.0",
-    "cross-env": "^5.2.0",
     "css-loader": "^2.1.1",
     "html-webpack-plugin": "^3.2.0",
     "husky": "^1.3.1",

--- a/packages/performance-profiler-plugin/package.json
+++ b/packages/performance-profiler-plugin/package.json
@@ -25,9 +25,9 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "prebuild": "npm run clean",
-    "build": "cross-env NODE_ENV=development webpack",
-    "build:prod": "cross-env NODE_ENV=production webpack",
-    "build:watch": "cross-env NODE_ENV=development webpack --watch",
+    "build": "webpack --mode=development",
+    "build:prod": "npm run build",
+    "build:watch": "webpack --watch --mode=development",
     "clean": "rimraf dist",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/packages/schematics/package.json
+++ b/packages/schematics/package.json
@@ -25,9 +25,9 @@
   "schematics": "./dist/collection.json",
   "scripts": {
     "start": "npm-run-all clean build:watch",
-    "build": "cross-env NODE_ENV=development webpack",
-    "build:prod": "cross-env NODE_ENV=production webpack",
-    "build:watch": "cross-env NODE_ENV=development webpack --watch",
+    "build": "webpack --mode=development",
+    "build:prod": "webpack --mode=production",
+    "build:watch": "webpack --watch --mode=development",
     "clean": "rimraf dist",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3863,14 +3863,6 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-cross-env@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.2.0.tgz#6ecd4c015d5773e614039ee529076669b9d126f2"
-  integrity sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==
-  dependencies:
-    cross-spawn "^6.0.5"
-    is-windows "^1.0.0"
-
 cross-spawn@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-3.0.1.tgz#1256037ecb9f0c5f79e3d6ef135e30770184b982"
@@ -6557,7 +6549,7 @@ is-utf8@^0.2.0:
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
   integrity sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=
 
-is-windows@^1.0.0, is-windows@^1.0.1, is-windows@^1.0.2:
+is-windows@^1.0.1, is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==


### PR DESCRIPTION
The current `performance-profiler-plugin` build with webpack's `--mode=production` causes the frontend to not load correctly. This is a temporary fix to ensure it loads correctly.