### PR TITLE
build: fixing prod build for profiler

### DIFF
--- a/packages/performance-profiler-plugin/package.json
+++ b/packages/performance-profiler-plugin/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "prebuild": "npm run clean",
     "build": "webpack --mode=development",
-    "build:prod": "cross-env NODE_ENV=production webpack",
+    "build:prod": "webpack --mode=production",
     "build:watch": "webpack --watch --mode=development",
     "clean": "rimraf dist",
     "test": "jest",

--- a/packages/performance-profiler-plugin/package.json
+++ b/packages/performance-profiler-plugin/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "prebuild": "npm run clean",
     "build": "webpack --mode=development",
-    "build:prod": "npm run build",
+    "build:prod": "cross-env NODE_ENV=production webpack",
     "build:watch": "webpack --watch --mode=development",
     "clean": "rimraf dist",
     "test": "jest",

--- a/packages/performance-profiler-plugin/webpack.config.js
+++ b/packages/performance-profiler-plugin/webpack.config.js
@@ -1,11 +1,9 @@
 const merge = require('webpack-merge');
 const webpackConfigBase = require('../webpack.config.base');
 
-const cfg = {
+module.exports = merge(webpackConfigBase, {
   devtool: 'eval',
   optimization: {
     concatenateModules: false,
   },
-};
-
-module.exports = merge(webpackConfigBase, cfg);
+});

--- a/packages/performance-profiler-plugin/webpack.config.js
+++ b/packages/performance-profiler-plugin/webpack.config.js
@@ -1,4 +1,11 @@
 const merge = require('webpack-merge');
 const webpackConfigBase = require('../webpack.config.base');
 
-module.exports = merge(webpackConfigBase);
+const cfg = {
+  devtool: 'eval',
+  optimization: {
+    concatenateModules: false,
+  },
+};
+
+module.exports = merge(webpackConfigBase, cfg);


### PR DESCRIPTION
Fixing production build on Performance Profiler Plugin.

Solving it through overriding flags automatically set/removed by passing `mode: production` to webpack. 